### PR TITLE
3.1.2

### DIFF
--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -271,10 +271,10 @@ class SimplyPrint(
         if line not in ["echo:busy: paused for user", "echo:busy: processing"]:
             return line
 
-        if line.strip() == "echo:busy: paused for user":
+        if "paused for user" in line.strip():
             self._logger.debug("received line: echo:busy: paused for user, setting fake_paused True")
             self.simply_print.fake_paused = True
-        if self.simply_print.fake_paused and line.strip() == "echo:busy: processing":
+        if self.simply_print.fake_paused and "busy: processing" in line.strip():
             self._logger.debug("received line: echo:busy: processing, setting fake_paused False")
             self.simply_print.fake_paused = False
 

--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -272,11 +272,11 @@ class SimplyPrint(
             return line
 
         if line.strip() == "echo:busy: paused for user":
-            self._logger.debug("received line: echo:busy: paused for user, setting fake_paused True")
-            self.simply_print.fake_paused = True
-        if self.simply_print.fake_paused and line.strip() == "echo:busy: processing":
-            self._logger.debug("received line: echo:busy: processing, setting fake_paused False")
-            self.simply_print.fake_paused = False
+            self._logger.debug("received line: echo:busy: paused for user, setting user_input_required True")
+            self.simply_print.user_input_required = True
+        if self.simply_print.user_input_required and line.strip() == "echo:busy: processing":
+            self._logger.debug("received line: echo:busy: processing, setting user_input_required False")
+            self.simply_print.user_input_required = False
 
         return line
 

--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -268,7 +268,7 @@ class SimplyPrint(
     #         self._logger.info("Just sent M106: {cmd}".format(**locals()))
 
     def gcode_received(self, comm_instance, line, *args, **kwargs):
-        if line.strip() != "echo:busy: paused for user" or line.strip() != "echo:busy: processing":
+        if line.strip() not in ["echo:busy: paused for user", "echo:busy: processing"]:
             self._logger.debug(line.strip())
             return line
 

--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -272,8 +272,10 @@ class SimplyPrint(
             return line
 
         if line == "echo:busy: paused for user":
+            self._logger.debug("received line: echo:busy: paused for user, setting fake_paused True")
             self.simply_print.fake_paused = True
         if self.simply_print.fake_paused and line == "echo:busy: processing":
+            self._logger.debug("received line: echo:busy: processing, setting fake_paused False")
             self.simply_print.fake_paused = False
 
         return line

--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -268,13 +268,13 @@ class SimplyPrint(
     #         self._logger.info("Just sent M106: {cmd}".format(**locals()))
 
     def gcode_received(self, comm_instance, line, *args, **kwargs):
-        if line not in ["echo:busy: paused for user", "echo:busy: processing"]:
+        if line.strip() != "echo:busy: paused for user" or line.strip() != "echo:busy: processing":
             return line
 
-        if "paused for user" in line.strip():
+        if line.strip() == "echo:busy: paused for user":
             self._logger.debug("received line: echo:busy: paused for user, setting fake_paused True")
             self.simply_print.fake_paused = True
-        if self.simply_print.fake_paused and "busy: processing" in line.strip():
+        if self.simply_print.fake_paused and line.strip() == "echo:busy: processing":
             self._logger.debug("received line: echo:busy: processing, setting fake_paused False")
             self.simply_print.fake_paused = False
 

--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -269,7 +269,6 @@ class SimplyPrint(
 
     def gcode_received(self, comm_instance, line, *args, **kwargs):
         if line.strip() not in ["echo:busy: paused for user", "echo:busy: processing"]:
-            self._logger.debug(line.strip())
             return line
 
         if line.strip() == "echo:busy: paused for user":

--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -268,13 +268,14 @@ class SimplyPrint(
     #         self._logger.info("Just sent M106: {cmd}".format(**locals()))
 
     def gcode_received(self, comm_instance, line, *args, **kwargs):
-        if line.strip() not in ["echo:busy: paused for user", "echo:busy: processing"]:
+        if line.strip() not in ["echo:busy: paused for user", "echo:busy: processing", "Unknown M code: M118 simplyprint unpause", "simplyprint unpause"]:
             return line
 
         if line.strip() == "echo:busy: paused for user":
             self._logger.debug("received line: echo:busy: paused for user, setting user_input_required True")
             self.simply_print.user_input_required = True
-        if self.simply_print.user_input_required and line.strip() == "echo:busy: processing":
+            self._printer.commands("M118 simplyprint unpause", force=True)
+        if self.simply_print.user_input_required and line.strip() in ["echo:busy: processing", "Unknown M code: M118 simplyprint unpause", "simplyprint unpause"]:
             self._logger.debug("received line: echo:busy: processing, setting user_input_required False")
             self.simply_print.user_input_required = False
 
@@ -335,7 +336,7 @@ Please uninstall SimplyPrint Cloud rather than just disable it, since it sets up
 that will continue to run if you disable it.
 """
 # Remember to bump the version in setup.py as well
-__plugin_version__ = "3.1.2rc4"
+__plugin_version__ = "3.1.2rc5"
 
 
 def __plugin_load__():

--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -271,10 +271,10 @@ class SimplyPrint(
         if line not in ["echo:busy: paused for user", "echo:busy: processing"]:
             return line
 
-        if line == "echo:busy: paused for user":
+        if line.strip() == "echo:busy: paused for user":
             self._logger.debug("received line: echo:busy: paused for user, setting fake_paused True")
             self.simply_print.fake_paused = True
-        if self.simply_print.fake_paused and line == "echo:busy: processing":
+        if self.simply_print.fake_paused and line.strip() == "echo:busy: processing":
             self._logger.debug("received line: echo:busy: processing, setting fake_paused False")
             self.simply_print.fake_paused = False
 

--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -269,6 +269,7 @@ class SimplyPrint(
 
     def gcode_received(self, comm_instance, line, *args, **kwargs):
         if line.strip() != "echo:busy: paused for user" or line.strip() != "echo:busy: processing":
+            self._logger.debug(line.strip())
             return line
 
         if line.strip() == "echo:busy: paused for user":
@@ -335,7 +336,7 @@ Please uninstall SimplyPrint Cloud rather than just disable it, since it sets up
 that will continue to run if you disable it.
 """
 # Remember to bump the version in setup.py as well
-__plugin_version__ = "3.1.2rc3"
+__plugin_version__ = "3.1.2rc4"
 
 
 def __plugin_load__():

--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -336,7 +336,7 @@ Please uninstall SimplyPrint Cloud rather than just disable it, since it sets up
 that will continue to run if you disable it.
 """
 # Remember to bump the version in setup.py as well
-__plugin_version__ = "3.1.2rc5"
+__plugin_version__ = "3.1.2rc6"
 
 
 def __plugin_load__():

--- a/octoprint_simplyprint/comm/monitor.py
+++ b/octoprint_simplyprint/comm/monitor.py
@@ -1,0 +1,174 @@
+import psutil
+import time
+
+
+class Monitor:
+
+	def __init__(self, network_exceptions, disk_exceptions, logger):
+		self.__logger = logger
+		self.__init_process()
+		self.__init_children()
+		self.__network_exceptions = network_exceptions
+		self.__disk_exceptions = disk_exceptions
+
+	def __get_cpu_temp(self, temp):
+		if temp is None:
+			return None
+		cpu_temp = None
+		if "coretemp" in temp:
+			cpu_temp = temp["coretemp"][0]._asdict()
+		if "cpu-thermal" in temp:
+			cpu_temp = temp["cpu-thermal"][0]._asdict()
+		if "cpu_thermal" in temp:
+			cpu_temp = temp["cpu_thermal"][0]._asdict()
+		if "soc_thermal" in temp:
+			cpu_temp = temp["soc_thermal"][0]._asdict()
+		return cpu_temp
+
+	def __init_process(self):
+		self.__process = psutil.Process()
+		self.__logger.debug("self.__process is now %r" % (self.__process,))
+		# First call so it does not return 0 on next call
+		self.__process.cpu_percent()
+
+	def get_cpu(self):
+		cpu_freq = psutil.cpu_freq()
+		self.__logger.debug("cpu_freq() : %r" % (cpu_freq,))
+		cores = psutil.cpu_percent(percpu=True)
+		self.__logger.debug("cpu_percent(percpu=True) : %r" % (cores,))
+		average = psutil.cpu_percent()
+		self.__logger.debug("cpu_percent() : %r" % (average,))
+		core_count = psutil.cpu_count(logical=False)
+		self.__logger.debug("cpu_count(logical=False) : %r" % (core_count,))
+		thread_count = psutil.cpu_count(logical=True)
+		self.__logger.debug("cpu_count(logical=True) : %r" % (thread_count,))
+		pids = len(psutil.pids())
+		self.__logger.debug("len(pids()) : %r" % (pids,))
+		boot_time = psutil.boot_time()
+		self.__logger.debug("boot_time() : %r" % (boot_time,))
+		return dict(
+			cores=cores,
+			average=average,
+			frequency=cpu_freq._asdict() if cpu_freq else dict(),
+			core_count=core_count,
+			thread_count=thread_count,
+			pids=pids,
+			uptime=int(time.time() - boot_time),
+			octoprint=self.__get_octoprint_cpu(average)
+		)
+
+	def __init_children(self):
+		try:
+			self.__children = self.__process.children(recursive=True)
+		except psutil.NoSuchProcess:
+			self.__logger.debug("No process found when calling children(recursive=True) on %r" % (self.__process,))
+			self.__init_process()
+			self.__children = self.__process.children(recursive=True)
+		for child in self.__children:
+			# First call so it does not return 0 on next call, process might die between calls
+			try:
+				child.cpu_percent()
+			except psutil.NoSuchProcess:
+				self.__logger.debug("No process found when calling cpu_percent() on %r" % (child,))
+				pass
+
+	def __get_octoprint_cpu(self, average):
+		try:
+			# Don't know why and how
+			# But his can sometimes raise a NoSuchProcessException
+			total_cpu = self.__process.cpu_percent()
+		except psutil.NoSuchProcess:
+			self.__logger.debug("No process found when calling cpu_percent() on %r" % (self.__process,))
+			self.__init_process()
+			total_cpu = self.__process.cpu_percent()
+		for child in self.__children:
+			try:
+				total_cpu += child.cpu_percent()
+			except psutil.NoSuchProcess:
+				self.__logger.debug("No process found when calling cpu_percent() on %r" % (child,))
+				pass
+		self.__init_children()
+		cpu_count = psutil.cpu_count()
+		self.__logger.debug("cpu_count() : %r" % (cpu_count,))
+		return min(total_cpu / cpu_count, average)
+
+	def get_cpu_temp(self):
+		# return dict(
+		# 	celsius=dict(
+		# 		current=20
+		# 	),
+		# 	fahrenheit=dict(
+		# 		current=50
+		# 	)
+		# )
+		temps_celsius = None
+		temps_fahrenheit = None
+		if hasattr(psutil, "sensors_temperatures"):
+			temps_celsius = psutil.sensors_temperatures()
+			self.__logger.debug("sensors_temperatures() : %r" % (temps_celsius,))
+			temps_fahrenheit = psutil.sensors_temperatures(fahrenheit=True)
+			self.__logger.debug("sensors_temperatures(fahrenheit=True) : %r" % (temps_fahrenheit,))
+		temps_c = self.__get_cpu_temp(temps_celsius)
+		temps_f = self.__get_cpu_temp(temps_fahrenheit)
+		return dict(
+			celsius=temps_c if temps_c else dict(),
+			fahrenheit=temps_f if temps_f else dict()
+		)
+
+	def get_memory(self):
+		virtual_memory = psutil.virtual_memory()
+		self.__logger.debug("virtual_memory() : %r" % (virtual_memory,))
+		return virtual_memory._asdict()
+
+	def get_partitions(self, all):
+		disk_partitions = psutil.disk_partitions()
+		self.__logger.debug("disk_partitions() : %r" % (disk_partitions,))
+		partitions = [partition._asdict() for partition in disk_partitions if partition.fstype and (all or partition.mountpoint not in self.__disk_exceptions)
+									and partition.fstype not in ["squashfs"]]
+		for partition in partitions:
+			disk_usage = psutil.disk_usage(partition["mountpoint"])
+			self.__logger.debug('disk_usage(partition["mountpoint"] : %r' % (disk_usage,))
+			partition.update(disk_usage._asdict())
+		return partitions
+
+	def get_network(self, all):
+		io_counters = psutil.net_io_counters(pernic=True)
+		self.__logger.debug("net_io_counters(pernic=True) : %r" % (io_counters,))
+		addrs = psutil.net_if_addrs()
+		self.__logger.debug("net_if_addrs() : %r" % (addrs,))
+		stats = psutil.net_if_stats()
+		self.__logger.debug("net_if_stats() : %r" % (stats,))
+		final = []
+		for nic_name in io_counters:
+			if all or nic_name not in self.__network_exceptions:
+				nic = dict(
+					name=nic_name,
+					addrs=[addr._asdict() for addr in addrs[nic_name]]
+				)
+				nic.update(io_counters[nic_name]._asdict())
+				if nic_name in stats:
+					nic.update(stats[nic_name]._asdict())
+				final.append(nic)
+		return final
+
+	def get_battery(self):
+		# return dict(
+		# 	percent=94,
+		# 	secsleft=16628,
+		# 	power_plugged=True
+		# )
+		bat = psutil.sensors_battery()
+		self.__logger.debug("sensors_battery() : %r" % (bat,))
+		if bat:
+			return bat._asdict()
+		return dict()
+
+	def get_all_resources(self):
+		return dict(
+			cpu=self.get_cpu(),
+			temp=self.get_cpu_temp(),
+			memory=self.get_memory(),
+			partitions=self.get_partitions(all=False),
+			network=self.get_network(all=False),
+			battery=self.get_battery()
+		)

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -687,7 +687,7 @@ class SimplyPrintComm:
                 else:
                     name = str(uuid.uuid1())
 
-                name = "sp_{}.gcode".format(name)
+                name = "{}.gcode".format(name)
 
                 status = self._process_file_request(download_url, name)
                 if not status:
@@ -1288,10 +1288,11 @@ class SimplyPrintComm:
         local = FileDestinations.LOCAL
 
         # Delete any old sp_* files
-        files = self.plugin._file_manager.list_files(local)
+        files = self.plugin._file_manager.list_files(local, "SimplyPrint")
         for file, data in files["local"].items():
-            if data["display"].startswith("sp_"):
-                self.plugin._file_manager.remove_file(local, data["path"])
+            # if data["display"].startswith("sp_"):
+            # assume we only upload to this folder and delete everything...
+            self.plugin._file_manager.remove_file(local, data["path"])
 
         if new_filename is None:
             new_filename = str(uuid.uuid1())
@@ -1328,7 +1329,7 @@ class SimplyPrintComm:
 
         try:
             canon_path, canon_filename = self.plugin._file_manager.canonicalize(
-                FileDestinations.LOCAL, upload.filename
+                FileDestinations.LOCAL, "SimplyPrint/{}".format(upload.filename)
             )
             future_path = self.plugin._file_manager.sanitize_path(FileDestinations.LOCAL, canon_path)
             future_filename = self.plugin._file_manager.sanitize_name(FileDestinations.LOCAL, canon_filename)

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -312,8 +312,11 @@ class SimplyPrintComm:
                 print_job = self.get_print_job()
                 if "completion" in print_job["progress"] and print_job["progress"]["completion"] is not None:
                     to_set["completion"] = round(float(print_job["progress"]["completion"]))
-                if "printTimeLeftOrigin" in print_job["progress"] and print_job["progress"]["printTimeLeftOrigin"] == "genius":
-                    to_set["completion"] = round(float(print_job["progress"]["printTime"] or 0) / (float(print_job["progress"]["printTime"] or 0) + float(print_job["progress"]["printTimeLeft"])) * 100)
+                if "printTimeLeftOrigin" in print_job["progress"] and print_job["progress"][
+                    "printTimeLeftOrigin"] == "genius":
+                    to_set["completion"] = round(float(print_job["progress"]["printTime"] or 0) / (
+                                float(print_job["progress"]["printTime"] or 0) + float(
+                            print_job["progress"]["printTimeLeft"])) * 100)
                 to_set["estimated_finish"] = print_job["progress"]["printTimeLeft"]
 
                 try:
@@ -391,7 +394,8 @@ class SimplyPrintComm:
                     self.first = False
 
                 if self._settings.get_boolean(["has_power_controller"]) and not self.has_checked_power_controller:
-                    helpers = self.plugin._plugin_manager.get_helpers("psucontrol") or self.plugin._plugin_manager.get_helpers("simplypowercontroller")
+                    helpers = self.plugin._plugin_manager.get_helpers(
+                        "psucontrol") or self.plugin._plugin_manager.get_helpers("simplypowercontroller")
                     if helpers:
                         if "get_psu_state" in helpers:
                             status = helpers["get_psu_state"]()
@@ -529,8 +533,11 @@ class SimplyPrintComm:
         if self.printer.is_printing():
             if self._settings.get_int(["display_while_printing_type"]) != 2:
                 print_job = self.get_print_job()
-                if "printTimeLeftOrigin" in print_job["progress"] and print_job["progress"]["printTimeLeftOrigin"] == "genius":
-                    progress = float(print_job["progress"]["printTime"] or 0) / (float(print_job["progress"]["printTime"] or 0) + float(print_job["progress"]["printTimeLeft"])) * 100
+                if "printTimeLeftOrigin" in print_job["progress"] and print_job["progress"][
+                    "printTimeLeftOrigin"] == "genius":
+                    progress = float(print_job["progress"]["printTime"] or 0) / (
+                                float(print_job["progress"]["printTime"] or 0) + float(
+                            print_job["progress"]["printTimeLeft"])) * 100
                 else:
                     progress = print_job["progress"]["completion"]
                 if progress is not None:
@@ -598,7 +605,8 @@ class SimplyPrintComm:
             pass
 
         if any_demand(demand_list, ["psu_on", "psu_keepalive"]):
-            helpers = self.plugin._plugin_manager.get_helpers("psucontrol") or self.plugin._plugin_manager.get_helpers("simplypowercontroller")
+            helpers = self.plugin._plugin_manager.get_helpers("psucontrol") or self.plugin._plugin_manager.get_helpers(
+                "simplypowercontroller")
             # psucontrol plugin
             if "turn_psu_on" in helpers:
                 helpers["turn_psu_on"]()
@@ -607,7 +615,8 @@ class SimplyPrintComm:
                 helpers["psu_on"]()
 
         if "psu_off" in demand_list:
-            helpers = self.plugin._plugin_manager.get_helpers("psucontrol") or self.plugin._plugin_manager.get_helpers("simplypowercontroller")
+            helpers = self.plugin._plugin_manager.get_helpers("psucontrol") or self.plugin._plugin_manager.get_helpers(
+                "simplypowercontroller")
             # psucontrol plugin
             if "turn_psu_off" in helpers:
                 helpers["turn_psu_off"]()
@@ -695,12 +704,16 @@ class SimplyPrintComm:
                 name = "{}.gcode".format(name)
 
                 self.downloading = True
-                download_thread = threading.Thread(target=self._process_file_request, args=(download_url, name), daemon=True)
+                download_thread = threading.Thread(target=self._process_file_request, args=(download_url, name),
+                                                   daemon=True)
                 download_thread.start()
+                # create a fake thread loop, which can be broken out of
+                internal_timer = time.time()
                 while self.downloading:
-                    self._logger.debug("still downloading {}".format(name))
-                    self.ping("&file_downloading=true&filename={}".format(name))
-                    time.sleep(5)
+                    if time.time() > (internal_timer + 5):
+                        self._logger.debug("still downloading {}".format(name))
+                        self.ping("&file_downloading=true&filename={}".format(name))
+                        internal_timer = time.time()
                 if not self.download_status:
                     if not self.printer.is_operational():
                         message = "Printer is not ready to print (state is not operational)"
@@ -1298,10 +1311,9 @@ class SimplyPrintComm:
         from octoprint.filemanager.destinations import FileDestinations
         local = FileDestinations.LOCAL
 
-        # Delete any old sp_* files
+        # Delete any old files in SimplyPrint folder
         files = self.plugin._file_manager.list_files(local, "SimplyPrint")
         for file, data in files["local"].items():
-            # if data["display"].startswith("sp_"):
             # assume we only upload to this folder and delete everything...
             self.plugin._file_manager.remove_file(local, data["path"])
 

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -85,6 +85,7 @@ class SimplyPrintComm:
         self.has_checked_filament_sensor = False
         self.previous_printer_text = ""
         self.state_timer = None
+        self.fake_paused = False
 
         self.last_connection_attempt = time.time()
         self.first = True
@@ -303,7 +304,6 @@ class SimplyPrintComm:
                     self.printer.is_printing()
                     or self.printer.is_cancelling()
                     or self.printer.is_pausing()
-                    or self.printer.is_pausing()
                     or self.printer.is_paused()
             ):
                 print_job = self.get_print_job()
@@ -324,7 +324,10 @@ class SimplyPrintComm:
 
             url += "&custom_sys_version=" + str(self.plugin._plugin_version)
 
-            url += "&pstatus=" + printer_state + "&extra=" + url_quote(json.dumps(to_set))
+            url += "&pstatus=" + printer_state
+            if self.fake_paused:
+                url += "&fakepaused"
+            url += "&extra=" + url_quote(json.dumps(to_set))
 
         return self._simply_get(url)
 
@@ -340,6 +343,8 @@ class SimplyPrintComm:
             result.update({"sd": {"ready": self.printer.is_sd_ready()}})
 
         result.update({"state": self.printer.get_current_data()["state"]})
+        if self.fake_paused:
+            result.update({"state": {"text": "Paused", "flags": {"paused": True}}})
 
         return result
 

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -343,7 +343,7 @@ class SimplyPrintComm:
             result.update({"sd": {"ready": self.printer.is_sd_ready()}})
 
         result.update({"state": self.printer.get_current_data()["state"]})
-        if self.user_input_required:
+        if self.user_input_required and self.printer.is_printing():
             result.update({"state": {"text": "Paused", "flags": {"paused": True}}})
 
         return result

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -326,6 +326,7 @@ class SimplyPrintComm:
 
             url += "&pstatus=" + printer_state
             if self.fake_paused:
+                self._logger.debug("using fakepaused")
                 url += "&fakepaused"
             url += "&extra=" + url_quote(json.dumps(to_set))
 

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -47,6 +47,7 @@ from octoprint.util.commandline import CommandlineCaller, CommandlineError
 from .constants import API_VERSION, UPDATE_URL, SIMPLYPRINT_PLUGIN_INSTALL_URL
 from .util import is_octoprint_setup, url_quote, has_internet, any_demand
 from . import webcam, startup, constants
+from .monitor import Monitor
 
 # default close_fds settings (borrowed from OctoPrint core :) )
 CLOSE_FDS = True
@@ -330,6 +331,8 @@ class SimplyPrintComm:
             if self.user_input_required:
                 url += "&userinputrequired"
             url += "&extra=" + url_quote(json.dumps(to_set))
+
+            url += "&health=" + url_quote(json.dumps(self.__monitor.get_all_resources()))
 
         return self._simply_get(url)
 

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -332,7 +332,7 @@ class SimplyPrintComm:
                 url += "&userinputrequired"
             url += "&extra=" + url_quote(json.dumps(to_set))
 
-            url += "&health=" + url_quote(json.dumps(self.__monitor.get_all_resources()))
+            url += "&health=" + url_quote(json.dumps(Monitor.get_all_resources()))
 
         return self._simply_get(url)
 

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -85,7 +85,7 @@ class SimplyPrintComm:
         self.has_checked_filament_sensor = False
         self.previous_printer_text = ""
         self.state_timer = None
-        self.fake_paused = False
+        self.user_input_required = False
 
         self.last_connection_attempt = time.time()
         self.first = True
@@ -324,13 +324,9 @@ class SimplyPrintComm:
 
             url += "&custom_sys_version=" + str(self.plugin._plugin_version)
 
-            if self.fake_paused:
-                self._logger.debug("using fakepaused")
-                printer_state = "Paused"
-                url += "&fakepaused"
-
             url += "&pstatus=" + printer_state
-
+            if self.user_input_required:
+                url += "&userinputrequired"
             url += "&extra=" + url_quote(json.dumps(to_set))
 
         return self._simply_get(url)
@@ -347,7 +343,7 @@ class SimplyPrintComm:
             result.update({"sd": {"ready": self.printer.is_sd_ready()}})
 
         result.update({"state": self.printer.get_current_data()["state"]})
-        if self.fake_paused:
+        if self.user_input_required:
             result.update({"state": {"text": "Paused", "flags": {"paused": True}}})
 
         return result

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -324,10 +324,13 @@ class SimplyPrintComm:
 
             url += "&custom_sys_version=" + str(self.plugin._plugin_version)
 
-            url += "&pstatus=" + printer_state
             if self.fake_paused:
                 self._logger.debug("using fakepaused")
+                printer_state = "Paused"
                 url += "&fakepaused"
+
+            url += "&pstatus=" + printer_state
+
             url += "&extra=" + url_quote(json.dumps(to_set))
 
         return self._simply_get(url)

--- a/octoprint_simplyprint/comm/simplyprint.py
+++ b/octoprint_simplyprint/comm/simplyprint.py
@@ -331,8 +331,8 @@ class SimplyPrintComm:
             if self.user_input_required:
                 url += "&userinputrequired"
             url += "&extra=" + url_quote(json.dumps(to_set))
-
-            url += "&health=" + url_quote(json.dumps(Monitor.get_all_resources()))
+            resources = Monitor(self._logger)
+            url += "&health=" + url_quote(json.dumps(resources.get_all_resources()))
 
         return self._simply_get(url)
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ plugin_name = "SimplyPrint"
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
 
-plugin_version = "3.1.2rc4"
+plugin_version = "3.1.2rc5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ plugin_name = "SimplyPrint"
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
 
-plugin_version = "3.1.2rc5"
+plugin_version = "3.1.2rc6"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ plugin_name = "SimplyPrint"
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
 
-plugin_version = "3.1.2rc6"
+plugin_version = "3.1.2rc7"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ plugin_name = "SimplyPrint"
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
 
-plugin_version = "3.1.2rc3"
+plugin_version = "3.1.2rc4"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ plugin_name = "SimplyPrint"
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
 
-plugin_version = "3.1.2rc2"
+plugin_version = "3.1.2rc3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
1. ~~Send current Z layer to SimplyPrint~~: uses `@simplyprint layer #` in slicer after layer change gcode
2. ~~could not convert "" to and integer~~: switched to `_settings.get` from `_settings.get_int` for public_port
3. ~~iwlist failed, can't get SSID~~: check for existence of iwlist and iwgetid in 2 paths for determining ssid name to handle different devices, returns early if neither is found
4. ~~Re-trying print start initiate; check what happens if you do self.printer.select_file when the printer isn't operational, and if the process to start a print somehow fails - right now we just give up instantly and tell the user the print couldn't be started, which results in the user having to re-upload and slice, so we wanna try a couple of times and wait a couple of seconds after a failed attempt, before simply giving up~~: will attempt to connect to printer 3 times with increasing delay, if successful will select file to print.
5. ~~Pause Related~~
a. ~~See if we can put content after @PAUSE, and get that content (@PAUSE get me)~~: will send message back to SP querystring parameter `pause_message=<message after @PAUSE>`
b. ~~Detect when a Prusa printer (possibly works for others too) is paused, and send a fake "paused" state to SP~~: uses internal user_input_required flag to include additional querystring parameter `&userinputrequired` and sets pstatus=Paused.
6. ~~Download Related~~
  a. ~~Async file download; right now, when the Pi downloads a file the rest of a code doesn't continue, so if it's a big file (or slow internet), the printer will show as "offline" in SimplyPrint while it downloads - we want it to be able to still communicate that it's online, but this one is a bit more awkward, as the code would have to still know that the download is ongoing, so it doesn't just start a million download processes~~: thread download process, but keep in loop with ping to SP server as querystring `&file_downloading=true&filename={filename}`
  b. ~~Place SimplyPrint-downloaded files in a folder called `SimplyPrint`~~
7. ~~Send Pi "health" details to server once every minute or so; CPU usage, ram, temperature etc.~~: utilized resource monitor's monitor.py and stripped out some stuff, could probably strip out more, but includes lots of data. passed in ping command with querystring param `&health=` with url_quoted json string. 