### PR TITLE
4.0.5

### DIFF
--- a/octoprint_simplyprint/__init__.py
+++ b/octoprint_simplyprint/__init__.py
@@ -43,6 +43,7 @@ SIMPLYPRINT_EVENTS = [
     Events.CONNECTED,
     Events.DISCONNECTING,
     Events.DISCONNECTED,
+    Events.CLIENT_AUTHED,
 
     Events.STARTUP,
     Events.SHUTDOWN,

--- a/octoprint_simplyprint/static/js/SimplyPrint.js
+++ b/octoprint_simplyprint/static/js/SimplyPrint.js
@@ -66,6 +66,15 @@ $(function () {
 
         self.loading = ko.observable(true);
 
+        self.ws_connected_server = ko.observable();
+        self.current_endpoint = ko.observable();
+        self.SimplyPrintPanelURL = ko.pureComputed(function(){
+            return (self.current_endpoint() === "test") ? "https://rewrite.simplyprint.io/panel" : "https://simplyprint.io/panel";
+        });
+        self.SimplyPrintEndpoint = ko.pureComputed(function(){
+            return "SimplyPrint active on " + self.current_endpoint() + " endpoint.";
+        });
+
         self.onAfterBinding = function () {
             // Chose #wizard_plugin_corewizard_onlinecheck because it seemed likely it would be there for all first time
             if (!self.settingsViewModel.settings.plugins.SimplyPrint.is_set_up() && !$('#wizard_plugin_corewizard_onlinecheck').length) {
@@ -78,14 +87,14 @@ $(function () {
             }
 
             self.loading(false);
-        }
+        };
 
         self.onWizardFinish = function(){
             // Show the welcome dialog if corewizard was open
             if (!self.settingsViewModel.settings.plugins.SimplyPrint.is_set_up() && $('#wizard_plugin_corewizard_onlinecheck').length) {
                 $('#SimplyPrintWelcome').modal("show");
             }
-        }
+        };
 
         function SetupRecommended() {
             setTimeout(function () {
@@ -112,7 +121,7 @@ $(function () {
                     SetupRecommended();
                 }
             });
-        }
+        };
 
         $("body").on("click", "#navbar_systemmenu ul li:nth-child(4)", function () {
             if (!self.settingsViewModel.settings.plugins.SimplyPrint.is_set_up()) {
@@ -240,10 +249,10 @@ $(function () {
             /*$("#wizard_dialog .button-finish[name='finish']").on("click", function () {
                 $("#simplyprint_dialog").modal("show");
             });*/
-        }
+        };
 
         self.pluginsLoadedCheck = function () {
-            let pluginSettings = self.settingsViewModel.settings.plugins.SimplyPrint
+            let pluginSettings = self.settingsViewModel.settings.plugins.SimplyPrint;
             if ($("#settings_plugin_pluginmanager_pluginlist tbody").html().length) {
                 //Plugins have been loaded (being called from the API async, not loaded with the page)
                 if (typeof pluginSettings.sp_installed_plugins === "undefined" || !Array.isArray(pluginSettings.sp_installed_plugins) || !pluginSettings.sp_installed_plugins.length) {
@@ -271,14 +280,14 @@ $(function () {
             } else {
                 setTimeout(self.pluginsLoadedCheck, 500);
             }
-        }
+        };
 
         self.ManagedBySimplyPrintAlert = function (extra = "", onlyPartly = false) {
             return `<div class="alert">
                 <img alt="SimplyPrint logo (all rights reserved)" src="plugin/SimplyPrint/static/img/sp_logo.png" style="margin-left: 10px;width: 19px;">
                 ${onlyPartly ? "Some features here are managed by SimplyPrint" : "This feature is managed by SimplyPrint"}${extra.length ? ". " + extra : ""}
             </div>`;
-        }
+        };
 
         self.DisableOverwrittenUI = function () {
             //Printer profiles
@@ -301,18 +310,17 @@ $(function () {
             $("#settings_gcodeScripts [data-bind=\"value: scripts_gcode_afterPrintCancelled\"]").prop("disabled", true);
             $("#settings_gcodeScripts [data-bind=\"value: scripts_gcode_afterPrintPaused\"]").prop("disabled", true);
             $("#settings_gcodeScripts [data-bind=\"value: scripts_gcode_beforePrintResumed\"]").prop("disabled", true);
-        }
+        };
 
         self.DisableOverwrittenUI();
         self.OctoSetupChanges();
 
         // Support for installing and uninstalling the SimplyPrintRpiSoftware (CP)
-        self.requestInProgress = ko.observable()
+        self.requestInProgress = ko.observable();
         self.doSetup = function () {
-            console.log("installing")
             self.requestInProgress(true);
-            OctoPrint.simpleApiCommand("SimplyPrint", "setup")
-        }
+            OctoPrint.simpleApiCommand("SimplyPrint", "setup");
+        };
 
         self.onDataUpdaterPluginMessage = function (plugin, data) {
             if (plugin !== "SimplyPrint") {
@@ -333,19 +341,23 @@ $(function () {
                         "text": "It looks like the dependency has been uninstalled. Please reinstall the plugin or contact us at contact@simplyprint.io",
                         "type": "error",
                         "hide": false,
-                    })
+                    });
                 } else if (data.message === "sp-rpi_error") {
                     new PNotify({
                         "title": "Unknown error enabling the SimplyPrint software",
                         "text": "Please get in contact so we can resolve this! contact@simplyprint.io",
                         "type": "error",
                         "hide": false,
-                    })
+                    });
+                } else if (data.message === "sp-ws-connection") {
+                    self.ws_connected_server(data.server);
+                    self.current_endpoint(data.endpoint);
                 }
             }
-        }
+        };
+
         self.doUninstall = function () {
-            self.requestInProgress(true)
+            self.requestInProgress(true);
             OctoPrint.simpleApiCommand("SimplyPrint", "uninstall")
                 .done(function (response) {
                     self.requestInProgress(false);
@@ -362,11 +374,11 @@ $(function () {
                                 "text": "It looks like the dependency has already been uninstalled. Failed to uninstall it again or contact us at contact@simplyprint.io",
                                 "type": "error",
                                 "hide": false,
-                            })
+                            });
                         }
                     }
-                })
-        }
+                });
+        };
     }
 
     OCTOPRINT_VIEWMODELS.push({

--- a/octoprint_simplyprint/static/js/SimplyPrint.js
+++ b/octoprint_simplyprint/static/js/SimplyPrint.js
@@ -77,7 +77,7 @@ $(function () {
             return "SimplyPrint active on " + self.current_endpoint() + " endpoint.";
         });
         self.online_label = ko.pureComputed(function(){
-            return self.is_online() ? 'online' : 'offline';
+            return self.is_online() ? 'has internet connection' : 'no internet connection';
         });
         self.online_label_class = ko.pureComputed(function(){
             return self.is_online() ? 'label label-success' : 'label label-warning';

--- a/octoprint_simplyprint/static/js/SimplyPrint.js
+++ b/octoprint_simplyprint/static/js/SimplyPrint.js
@@ -67,12 +67,26 @@ $(function () {
         self.loading = ko.observable(true);
 
         self.ws_connected_server = ko.observable();
+        self.is_online = ko.observable(false);
+        self.ws_connected = ko.observable(false);
         self.current_endpoint = ko.observable();
         self.SimplyPrintPanelURL = ko.pureComputed(function(){
             return (self.current_endpoint() === "test") ? "https://rewrite.simplyprint.io/panel" : "https://simplyprint.io/panel";
         });
         self.SimplyPrintEndpoint = ko.pureComputed(function(){
             return "SimplyPrint active on " + self.current_endpoint() + " endpoint.";
+        });
+        self.online_label = ko.pureComputed(function(){
+            return self.is_online() ? 'online' : 'offline';
+        });
+        self.online_label_class = ko.pureComputed(function(){
+            return self.is_online() ? 'label label-success' : 'label label-warning';
+        });
+        self.ws_connected_label = ko.pureComputed(function(){
+            return self.ws_connected() ? 'connected' : 'disconnected';
+        });
+        self.ws_connected_label_class = ko.pureComputed(function(){
+            return self.ws_connected() ? 'label label-success' : 'label label-warning';
         });
 
         self.onAfterBinding = function () {
@@ -349,9 +363,11 @@ $(function () {
                         "type": "error",
                         "hide": false,
                     });
-                } else if (data.message === "sp-ws-connection") {
+                } else if (data.message === "sp-connection") {
                     self.ws_connected_server(data.server);
                     self.current_endpoint(data.endpoint);
+                    self.is_online(data.is_online);
+                    self.ws_connected(data.ws_connected);
                 }
             }
         };

--- a/octoprint_simplyprint/templates/SimplyPrint_navbar.jinja2
+++ b/octoprint_simplyprint/templates/SimplyPrint_navbar.jinja2
@@ -1,6 +1,6 @@
 <div id="simplyprint_plugin_navbar">
     <div class="nav navbar-text">
-        <a href="https://simplyprint.io/panel" target="_blank"><img alt="SimplyPrint logo (all rights reserved)" src="plugin/SimplyPrint/static/img/sp_logo.png" title="SimplyPrint active" style="width: 28px;"></a>
+        <a data-bind="attr: {href: SimplyPrintPanelURL, title: SimplyPrintEndpoint}" href="https://simplyprint.io/panel" target="_blank"><img alt="SimplyPrint logo (all rights reserved)" src="plugin/SimplyPrint/static/img/sp_logo.png" style="width: 28px;"></a>
 
         <strong>
             <span id="simplyprint_version_wrapper">v{{ plugin_SimplyPrint_version }}</span>

--- a/octoprint_simplyprint/templates/SimplyPrint_settings.jinja2
+++ b/octoprint_simplyprint/templates/SimplyPrint_settings.jinja2
@@ -3,7 +3,7 @@
 <p>There isn't much to see in here :) All settings are located in the SimplyPrint panel, and everything that needs to be
 synced to OctoPrint and your Raspberry Pi, will do so automatically.</p>
 
-<p>Currently connected to <span class="label label-info" data-bind="text: current_endpoint"></span> endpoint on server <span class="label label-info" data-bind="text: ws_connected_server"></span>.</p>
+<p>Currently <span class="label" data-bind="text: online_label, class: online_label_class"></span> and <span class="label" data-bind="text: ws_connected_label, class: ws_connected_label_class"></span> <span data-bind="text: ws_connected() ? 'to' : 'from'"></span> <span class="label label-info" data-bind="text: current_endpoint"></span> endpoint  <!-- ko if: ws_connected -->on server <span class="label label-info" data-bind="text: ws_connected_server, css: {'label-error': ws_connected_server == 'error'}"></span><!-- /ko --></p>
 <a data-bind="attr: {href: SimplyPrintPanelURL, title: SimplyPrintEndpoint}" href="https://simplyprint.io/panel" target="_blank" class="btn btn-primary">Go to the SimplyPrint panel</a>
 
 {#

--- a/octoprint_simplyprint/templates/SimplyPrint_settings.jinja2
+++ b/octoprint_simplyprint/templates/SimplyPrint_settings.jinja2
@@ -3,7 +3,8 @@
 <p>There isn't much to see in here :) All settings are located in the SimplyPrint panel, and everything that needs to be
 synced to OctoPrint and your Raspberry Pi, will do so automatically.</p>
 
-<a href="https://simplyprint.io/panel" target="_blank" class="btn btn-primary">Go to the SimplyPrint panel</a>
+<p>Currently connected to <span class="label label-info" data-bind="text: current_endpoint"></span> endpoint on server <span class="label label-info" data-bind="text: ws_connected_server"></span>.</p>
+<a data-bind="attr: {href: SimplyPrintPanelURL, title: SimplyPrintEndpoint}" href="https://simplyprint.io/panel" target="_blank" class="btn btn-primary">Go to the SimplyPrint panel</a>
 
 {#
 <p>

--- a/octoprint_simplyprint/websocket/constants.py
+++ b/octoprint_simplyprint/websocket/constants.py
@@ -23,3 +23,5 @@ WS_PROD_ENDPOINT = "wss://ws.simplyprint.io/%s/p" % (SP_BACKEND_VERSION, )
 
 PLUGIN_INSTALL_URL = "https://github.com/SimplyPrint/OctoPrint-SimplyPrint/archive/master.zip"
 TEST_PLUGIN_INSTALL_URL = "https://github.com/Arksine/OctoPrint-SimplyPrint/dev-sp-websocket-20220414/master.zip"
+
+LOGS_UPLOAD_URL = "https://apirewrite.simplyprint.io/printers/ReceiveLogs?pid="

--- a/octoprint_simplyprint/websocket/constants.py
+++ b/octoprint_simplyprint/websocket/constants.py
@@ -18,7 +18,7 @@
 #
 
 SP_BACKEND_VERSION = "0.1"
-WS_TEST_ENDPOINT = "wss://testws.simplyprint.io/%s/p" % (SP_BACKEND_VERSION, )
+WS_TEST_ENDPOINT = "wss://testws2.simplyprint.io/%s/p" % (SP_BACKEND_VERSION, )
 WS_PROD_ENDPOINT = "wss://ws.simplyprint.io/%s/p" % (SP_BACKEND_VERSION, )
 
 PLUGIN_INSTALL_URL = "https://github.com/SimplyPrint/OctoPrint-SimplyPrint/archive/master.zip"

--- a/octoprint_simplyprint/websocket/simplyprint.py
+++ b/octoprint_simplyprint/websocket/simplyprint.py
@@ -1424,6 +1424,7 @@ class SimplyPrintWebsocket:
             except Exception:
                 return
         if message == self.cache.message:
+            self._logger.debug(f"not setting printer display, cached message: {message}")
             return
         self.cache.message = message
         if self.settings.get_boolean(["display_branding"]) or not self.is_set_up:
@@ -1432,6 +1433,7 @@ class SimplyPrintWebsocket:
             else:
                 prefix = "[SimplyPrint] "
             message = prefix + message
+        self._logger.debug(f"setting printer display: {message}")
         self._loop.run_in_executor(None, self.printer.commands, f"M117 {message}")
 
     async def _reset_printer_display(self, eventtime: float) -> float:

--- a/octoprint_simplyprint/websocket/simplyprint.py
+++ b/octoprint_simplyprint/websocket/simplyprint.py
@@ -77,7 +77,7 @@ VALID_STATES = [
 ]
 PRE_SETUP_EVENTS = [
     "connection", "state_change", "shutdown", "machine_data", "keepalive",
-    "firmware"
+    "firmware", "installed_plugins"
 ]
 
 class SimplyPrintWebsocket:

--- a/octoprint_simplyprint/websocket/simplyprint.py
+++ b/octoprint_simplyprint/websocket/simplyprint.py
@@ -382,13 +382,16 @@ class SimplyPrintWebsocket:
                         f"Failed to connect to SimplyPrint")
                 failed_attempts += 1
                 if not failed_attempts % 10:
-                    self.set_display_message("Can't reach SP", True)
-                    self.reset_printer_display_timer.start(delay=120)
                     self.is_online = await self._loop.run_in_executor(
                         None,
                         functools.partial(
                             server_reachable, "www.google.com", 80
                         ))
+                    if not self.is_online:
+                        self.set_display_message(f"No Internet", True)
+                    else:
+                        self.set_display_message("Can't reach SP", True)
+                    # self.reset_printer_display_timer.start(delay=120)
             else:
                 if failed_attempts:
                     self.set_display_message("Back online!", True)

--- a/octoprint_simplyprint/websocket/simplyprint.py
+++ b/octoprint_simplyprint/websocket/simplyprint.py
@@ -656,6 +656,20 @@ class SimplyPrintWebsocket:
             self._loop.run_in_executor(
                 None, self.sys_manager.restart_octoprint
             )
+        elif demand == "goto_ws_prod":
+            self.test = False
+            self._set_ws_url()
+            self.settings.set(["endpoint"], "production")
+            self.settings.save(trigger_event=True)
+            self.close()
+            self._connect()
+        elif demand == "goto_ws_test":
+            self.test = True
+            self._set_ws_url()
+            self.settings.set(["endpoint"], "test")
+            self.settings.save(trigger_event=True)
+            self.close()
+            self._connect()
         else:
             self._logger.debug(f"Unknown demand: {demand}")
 

--- a/octoprint_simplyprint/websocket/simplyprint.py
+++ b/octoprint_simplyprint/websocket/simplyprint.py
@@ -1405,7 +1405,7 @@ class SimplyPrintWebsocket:
         if message == self.cache.message:
             return
         self.cache.message = message
-        if self.settings.get_boolean(["display_branding"]):
+        if self.settings.get_boolean(["display_branding"]) or not self.is_set_up:
             if short_branding or len(message) > 7:
                 prefix = "[SP] "
             else:

--- a/octoprint_simplyprint/websocket/simplyprint.py
+++ b/octoprint_simplyprint/websocket/simplyprint.py
@@ -420,7 +420,9 @@ class SimplyPrintWebsocket:
                     self.settings.set(["printer_id"], "")
                     self.settings.set(["printer_name"], "")
                     if "short_id" in data:
-                        self.settings.set(["temp_short_setup_id"], data["short_id"])
+                        short_id = data.get("short_id")
+                        self.settings.set(["temp_short_setup_id"], short_id)
+                        self.set_display_message(f"Setup: {short_id}")
                     self.settings.save(trigger_event=True)
                 interval = data.get("interval")
                 self._set_intervals(interval)
@@ -453,6 +455,7 @@ class SimplyPrintWebsocket:
                 self._logger.debug(f"Invalid short_id received: {short_id}")
             else:
                 self.settings.set(["temp_short_setup_id"], data["short_id"])
+                self.set_display_message(f"Setup: {short_id}")
                 self.settings.save(trigger_event=True)
             self._set_ws_url()
         elif event == "complete_setup":
@@ -1342,7 +1345,7 @@ class SimplyPrintWebsocket:
 
     def set_display_message(self, message: str, short_branding=False) -> None:
         enabled = self.settings.get_boolean(["display_enabled"])
-        if not self.is_set_up or not enabled:
+        if (not self.is_set_up or not enabled) and not message.startswith("Setup:"):
             return
         if not isinstance(message, str):
             try:

--- a/octoprint_simplyprint/websocket/simplyprint.py
+++ b/octoprint_simplyprint/websocket/simplyprint.py
@@ -701,6 +701,8 @@ class SimplyPrintWebsocket:
                 r = requests.post(url, data=data, files=multiple_files, timeout=900)
                 if r.status_code == 200 and r.json()["status"]:
                     self.send_sp("logs_sent", r.json())
+                else:
+                    self._logger.debug(f"Error uploading logs, server response: {r.text}")
             else:
                 self._logger.debug("Total log post size is too large.")
         except Exception as e:

--- a/octoprint_simplyprint/websocket/simplyprint.py
+++ b/octoprint_simplyprint/websocket/simplyprint.py
@@ -1199,9 +1199,10 @@ class SimplyPrintWebsocket:
 
     def _on_firmware_warning(self, payload: Dict[str, Any]) -> None:
         self.cache.firmware_warning = payload
-        fw_info = self.cache.firmware_info
-        fw_info["unsafe"] = True
-        self.send_sp("firmware", fw_info)
+        # fw_info = self.cache.firmware_info
+        # fw_info["unsafe"] = True
+        # self.send_sp("firmware", fw_info)
+        self.send_sp("firmware_warning", payload)
 
     def _send_firmware_data(self, payload: Dict[str, Any]) -> None:
         fw_info = {"fw": payload, "raw": True, "unsafe": False}

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_name = "SimplyPrint"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
-plugin_version = "4.0.5dev1"
+plugin_version = "4.0.5dev2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_name = "SimplyPrint"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
-plugin_version = "4.0.5dev3"
+plugin_version = "4.0.5"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_name = "SimplyPrint"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
-plugin_version = "4.0.1"
+plugin_version = "4.0.2dev1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_name = "SimplyPrint"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
-plugin_version = "4.0.3"
+plugin_version = "4.0.5dev1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_name = "SimplyPrint"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
 # Remember to bump the version in octoprint_simplyprint/__init__.py as well
-plugin_version = "4.0.5dev2"
+plugin_version = "4.0.5dev3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
* add `installed_plugins` to PRE_SETUP_EVENTS, #43 
* switch to `firmware_warning` message, #44 
* always show setup code on printer
* add ability to switch WS connections between production and test via demand
* add `send_logs` demand for uploading requested logs from SP
* show connection details in plugin's settings