### PR TITLE
switch from logger exception to warning

### DIFF
--- a/octoprint_simplyprint/websocket/system.py
+++ b/octoprint_simplyprint/websocket/system.py
@@ -109,7 +109,7 @@ class SystemQuery:
                             return None, line.split(":")[1].strip()
 
         except Exception:
-            self._logger.exception("Failed to retrieve wifi interfaces")
+            self._logger.warning("Failed to retrieve wifi interfaces")
         return None, None
 
     def get_network_info(self) -> Dict[str, Any]:


### PR DESCRIPTION
I think this will resolve issues with errors like this....by not raising an exception, but a warning. 

```
2025-06-19 17:35:02,067 - octoprint.server - INFO - Listening on http://127.0.0.1:5000
2025-06-19 17:35:02,101 - octoprint.plugins.simplyprint - ERROR - Failed to retrieve wifi interfaces
Traceback (most recent call last):
  File "/opt/octopi/oprint/lib/python3.11/site-packages/octoprint_simplyprint/websocket/system.py", line 98, in _get_wifi_interface
    ret, stdout, stderr = self.command_line.checked_call(cmd)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/octopi/oprint/lib/python3.11/site-packages/octoprint/util/commandline.py", line 156, in checked_call
    raise CommandlineError(returncode, stdout, stderr)
octoprint.util.commandline.CommandlineError: (255, [], [])
```